### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/container_status/tasks/main.yml
+++ b/roles/container_status/tasks/main.yml
@@ -2,13 +2,13 @@
 # source: https://github.com/openstack/tripleo-validations/blob/master/roles/container_status/tasks/main.yaml
 
 - name: Set container_cli fact from the inventory
-  set_fact:
+  ansible.builtin.set_fact:
     container_cli: "{{ hostvars[inventory_hostname].container_cli |default('docker', true) }}"
 
 - name: Get failed containers for podman
   changed_when: false
   become: true
-  command: >
+  ansible.builtin.command: >
     {{ container_cli }}
     {% raw %}
     ps -a --filter 'status=exited' --format '{{ .Names }} {{ .Status }}'
@@ -16,7 +16,7 @@
   register: failed_containers
 
 - name: Fail if we detect failed containers
-  fail:
+  ansible.builtin.fail:
     msg: "Failed container detected: {{ item }}."
   when: item is not match(".* Exited \(0\) .* ago")
   loop: "{{ failed_containers.stdout_lines }}"


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-validations/roles/container_status Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
