### PR TITLE
Use ansible builtin tasks

### DIFF
--- a/roles/kernel_version/tasks/main.yml
+++ b/roles/kernel_version/tasks/main.yml
@@ -2,6 +2,6 @@
 # source https://github.com/openstack/tripleo-validations/blob/master/roles/check_kernel_version/tasks/main.yml
 
 - name: Check kernel version
-  fail:
+  ansible.buitlin.fail:
     msg: "{{ kernel_version_expected }} does not match configured kernel_version {{ kernel_version_fact }}"
   when: kernel_version_expected not in kernel_version_fact


### PR DESCRIPTION
- Use the ansible.builtin.tasks in the ansible-collection-validations/roles/kernel_version Repo
- This is partly from the github issue: osism/issues#63

Signed-off-by: Ramona Rautenberg <rautenberg@osism.tech>
