### PR TITLE
[tempest] Write config and img_file on manager

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -11,7 +11,7 @@ tempest_workdir: /opt/tempest
 tempest_workspace_name: tempest
 
 tempest_tag: latest
-tempest_image: "{{ docker_registry_tempest }}/osism/tempest: {{ tempest_tag }}"
+tempest_image: "{{ docker_registry_tempest }}/osism/tempest:{{ tempest_tag }}"
 tempest_container_name: "{{ tempest_workspace_name }}"
 
 tempest_include_regex: '^tempest\.scenario\..*$|^barbican_tempest_plugin\.tests\.scenario.*$|^designate_tempest_plugin\.tests\.scenario\..*$|^octavia_tempest_plugin\.tests\.scenario\.v2\..*$'

--- a/roles/tempest/tasks/main.yml
+++ b/roles/tempest/tasks/main.yml
@@ -1,18 +1,18 @@
 ---
-- name: Create refstack workdir
+- name: Create tempest workdir
   become: true
   delegate_to: "{{ groups[tempest_runtime_group] | first }}"
   ansible.builtin.file:
-    path: "{{ refstack_workdir }}"
+    path: "{{ tempest_workdir }}"
     state: directory
     mode: 0750
     owner: "{{ operator_user }}"
-    group: "{{ operator_user }}"
+    group: "{{ operator_group }}"
 
 - name: Check for existing tempest initialisation
   delegate_to: "{{ groups[tempest_runtime_group] | first }}"
   ansible.builtin.stat:
-    path: "{{ tempest_workdir }}/tempest/.stestr.conf"
+    path: "{{ tempest_workdir }}/.stestr.conf"
   register: _stestr_conf
 
 - name: Init tempest
@@ -82,20 +82,24 @@
       openstack.cloud.catalog_service_info:
         <<: *os_auth
       register: _service_catalog
+    - name: Register img_file name
+      when:
+        - tempest_img_file is undefined
+      ansible.builtin.set_fact:
+        _img_file_name: "{{ _images.results | map(attribute='images') | first | map(attribute='name') | first | replace(' ', '_') }}"
     - name: Download img_file from image_ref
       when:
         - tempest_img_file is undefined
       vars:
-        _img_file_name: "{{ _images.results | map(attribute='images') | first | map(attribute='name') | first | replace(' ', '_') }}"
         service_id: "{{ _service_catalog.services | selectattr('type', 'equalto', 'image') | selectattr('is_enabled', 'truthy') | map(attribute='id') | first }}"
+      delegate_to: "{{ groups[tempest_runtime_group] | first }}"
       ansible.builtin.get_url:
         headers: *os_auth_headers
-        dest: "/tempest/{{ _img_file_name }}"
+        dest: "{{ tempest_workdir }}/{{ _img_file_name }}"
         mode: '0640'
-        owner: dragon
-        group: dragon
+        owner: "{{ operator_user }}"
+        group: "{{ operator_group }}"
         url: "{{ _endpoints.json.endpoints | selectattr('interface', 'equalto', 'public') | selectattr('service_id', 'equalto', service_id) | map(attribute='url') | first }}{{ _images.results | map(attribute='images') | first | map(attribute='file') | first }}"
-      register: _img_file
     - name: Get network API extensions
       when:
         - tempest_api_extensions is undefined
@@ -125,7 +129,7 @@
   when:
     - tempest_img_file is undefined
   ansible.builtin.set_fact:
-    tempest_img_file: "{{ _img_file.dest }}"
+    tempest_img_file: "/tempest/{{ _img_file_name }}"
 
 - name: Resolve floating network ID
   block:  # noqa: osism-fqcn
@@ -192,11 +196,12 @@
             _flavors_created.results | map(attribute='flavor') | map(attribute='id') | last
           }}
         _floating_ip_network_id: "{{ _floating_networks.networks | selectattr('is_router_external', 'truthy', 'convert_bool=True') | map(attribute='id') | first }}"
+      delegate_to: "{{ groups[tempest_runtime_group] | first }}"
       ansible.builtin.template:
         src: tempest.conf.j2
-        dest: "/tempest/etc/tempest.conf"
-        owner: dragon
-        group: dragon
+        dest: "{{ tempest_workdir }}/etc/tempest.conf"
+        owner: "{{ operator_user }}"
+        group: "{{ operator_group }}"
         mode: '0640'
     - name: Run tempest tests
       vars:

--- a/roles/tempest/templates/tempest.conf.j2
+++ b/roles/tempest/templates/tempest.conf.j2
@@ -1,13 +1,13 @@
 # {{ ansible_managed }}
 
 [DEFAULT]
-log_dir = {{ tempest_share_mount }}/tempest/logs
+log_dir = /tempest/logs
 log_file = tempest.log
 
 resource_name_prefix = osism-validation-tempest
 
 [oslo_concurrency]
-lock_path = {{ tempest_share_mount }}/tempest/tempest_lock
+lock_path = /tempest/tempest_lock
 
 [auth]
 use_dynamic_credentials = true


### PR DESCRIPTION
* Delegate the creation of tempest config and the download of the `img_file` to the manager node.
* Replace hardcoded user and groups with `operator_user` and `operator_group` variables.
* Some minor fixes