### PR TITLE
Allow filtering on arbitrary labels in prometheus-alert-status

### DIFF
--- a/roles/prometheus_alert_status/defaults/main.yml
+++ b/roles/prometheus_alert_status/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 prometheus_alert_status_endpoint: https://api-int.testbed.osism.xyz:9091
-prometheus_alert_status_filter_rule_by_name: []
+prometheus_alert_status_filter:
+  alertname: "{{ prometheus_alert_status_filter_rule_by_name | default([]) }}"
 prometheus_alert_status_user: admin
 prometheus_alert_status_password: password

--- a/roles/prometheus_alert_status/tasks/main.yml
+++ b/roles/prometheus_alert_status/tasks/main.yml
@@ -31,18 +31,25 @@
 
 - name: Filter alert list
   ansible.builtin.set_fact:
-    _alerts_filtered: "{{ _alerts.json.data.alerts | rejectattr('labels.alertname', 'in', prometheus_alert_status_filter_rule_by_name) }}"
+    _alerts_filtered: "{{
+      _alerts_filtered | default(_alerts.json.data.alerts)
+                       | selectattr('labels.' + item.label, 'defined')
+                       | rejectattr('labels.' + item.label, 'in', item.filter)
+                       | union(_alerts_filtered | default(_alerts.json.data.alerts)
+                                                | selectattr('labels.' + item.label, 'undefined'))
+  }}"
+  loop: "{{ prometheus_alert_status_filter | dict2items(key_name='label', value_name='filter') }}"
 
 - name: Show alerts
   ansible.builtin.debug:
     msg: "{{ item }}"
-  loop: "{{ _alerts_filtered }}"
+  loop: "{{ _alerts_filtered | default(_alerts.json.data.alerts) }}"
   loop_control:
     label: "{{ item.labels }}"
 
 - name: Assert there are no pending or firing alerts
   ansible.builtin.assert:
     that:
-      - _alerts_filtered | length == 0
+      - _alerts_filtered | default(_alerts.json.data.alerts) | length == 0
     success_msg: 'No alerts are pending/firing'
-    fail_msg: "There are {{ _alerts_filtered | length }} alerts pending/firing"
+    fail_msg: "There are {{ _alerts_filtered | default(_alerts.json.data.alerts) | length }} alerts pending/firing"


### PR DESCRIPTION
The `prometheus-alert-status` role is extended to allow filtering of arbitrary labels, while keeping the current behaviour.

A use case for this is ignoring alerts with a low severity.

Part of https://github.com/osism/issues/issues/1009