### PR TITLE
tempest: use /share as workdir

### DIFF
--- a/roles/refstack/defaults/main.yml
+++ b/roles/refstack/defaults/main.yml
@@ -13,7 +13,7 @@ refstack_guideline: "2022.11"
 refstack_keystone_endpoint: https://api.testbed.osism.xyz:5000/v3
 refstack_ca_cert: /etc/ssl/certs/ca-certificates.crt
 
-refstack_workdir: /share/refstack
+refstack_workdir: /opt/refstack
 refstack_cloud: admin
 
 refstack_admin_users:

--- a/roles/refstack/tasks/prepare.yml
+++ b/roles/refstack/tasks/prepare.yml
@@ -1,5 +1,6 @@
 ---
 - name: Create refstack workdir
+  become: true
   ansible.builtin.file:
     path: "{{ refstack_workdir }}"
     state: directory

--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -7,7 +7,7 @@ docker_registry_tempest: quay.io
 tempest_manager: testbed-manager
 
 tempest_runtime_group: manager
-tempest_workdir: /opt/tempest
+tempest_workdir: /share/tempest
 tempest_workspace_name: tempest
 
 tempest_tag: latest

--- a/roles/tempest/tasks/main.yml
+++ b/roles/tempest/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Create tempest workdir
-  become: true
   delegate_to: "{{ groups[tempest_runtime_group] | first }}"
   ansible.builtin.file:
     path: "{{ tempest_workdir }}"


### PR DESCRIPTION
The tempest role runs within the manager rervice. Therefore, the workdir should be created on /share by default.

Revert e18836c9a8eb69652a36ce8992d6bbf006f6ca72