### PR TITLE
Add role to verify network connectivity

### DIFF
--- a/roles/network_connectivity/README.rst
+++ b/roles/network_connectivity/README.rst
@@ -1,0 +1,5 @@
+This role runs a conectivity check between nodes considering the configured MTU.
+
+Set variable `group` to specify the group of hosts to check.
+Set variable `network_cidr` to the CIDR of the network you want to test
+Set variable `ping_count` to the number of test packets you want to send

--- a/roles/network_connectivity/README.rst
+++ b/roles/network_connectivity/README.rst
@@ -1,5 +1,0 @@
-This role runs a conectivity check between nodes considering the configured MTU.
-
-Set variable `group` to specify the group of hosts to check.
-Set variable `network_cidr` to the CIDR of the network you want to test
-Set variable `ping_count` to the number of test packets you want to send

--- a/roles/network_connectivity/defaults/main.yml
+++ b/roles/network_connectivity/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+group: all
+network_cidr: 127.0.0.0/8
+ping_count: 1

--- a/roles/network_connectivity/defaults/main.yml
+++ b/roles/network_connectivity/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-group: all
-network_cidr: 127.0.0.0/8
-ping_count: 1
+network_connectivity_group: all
+network_connectivity_network_cidr: 127.0.0.0/8
+network_connectivity_ping_count: 1

--- a/roles/network_connectivity/meta/main.yml
+++ b/roles/network_connectivity/meta/main.yml
@@ -1,0 +1,15 @@
+---
+galaxy_info:
+  author: Jan Horstmann
+  description: Role osism.validations.network_connectivity
+  company: OSISM GmbH
+  license: Apache License 2.0
+  min_ansible_version: 2.13.0
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+  galaxy_tags:
+    - osism
+    - system
+dependencies: []

--- a/roles/network_connectivity/tasks/main.yml
+++ b/roles/network_connectivity/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Assert provided group contains multiple hosts
   ansible.builtin.assert:
-    that: group  | length > 1
+    that: network_connectivity_group | length > 1
 
 - name: Assert provided network is valid
   ansible.builtin.assert:
-    that: network_cidr | ansible.utils.ipaddr
+    that: network_connectivity_network_cidr | ansible.utils.ipaddr
 
 - name: Run ping check with maximum possible length
   ansible.builtin.command:
@@ -24,7 +24,7 @@
       - "{{ mtu | int - ip_header_size | int - icmp_header_size | int }}"
       # send specified packet count
       - -c
-      - "{{ ping_count }}"
+      - "{{ network_connectivity_ping_count }}"
       - "{{ item }}"
   vars:
     ip_version: >-
@@ -78,7 +78,7 @@
     icmp_header_size: '8'
   loop: >-
     {{
-      group
+      network_connectivity_group
       | difference([inventory_hostname])
       | map('extract', hostvars, 'ansible_facts')
       | map('dict2items')

--- a/roles/network_connectivity/tasks/main.yml
+++ b/roles/network_connectivity/tasks/main.yml
@@ -1,0 +1,103 @@
+---
+- name: Assert provided group contains multiple hosts
+  ansible.builtin.assert:
+    that: group  | length > 1
+
+- name: Assert provided network is valid
+  ansible.builtin.assert:
+    that: network_cidr | ansible.utils.ipaddr
+
+- name: Run ping check with maximum possible length
+  ansible.builtin.command:
+    argv:
+      - /bin/ping
+      # quiet
+      - -q
+      # do not fragment
+      - -M
+      - do
+      # set source IP
+      - -I
+      - "{{ ip_address }}"
+      # use MTU sized packets
+      - -s
+      - "{{ mtu | int - ip_header_size | int - icmp_header_size | int }}"
+      # send specified packet count
+      - -c
+      - "{{ ping_count }}"
+      - "{{ item }}"
+  vars:
+    ip_version: >-
+      {{
+        'ipv4'
+        if network_cidr | ansible.utils.ipv4 | length > 0
+        else (
+          'ipv6'
+          if network_cidr | ansible.utils.ipv6 | length > 0
+          else
+          None
+        )
+      }}
+    ip_address: >-
+      {{
+        ansible_facts
+        | dict2items
+        | map(attribute='value')
+        | selectattr(ip_version, 'defined')
+        | map(attribute=ip_version)
+        | selectattr('address', 'defined')
+        | map(attribute='address')
+        | ansible.utils.ipaddr(network_cidr)
+        | list
+        | first
+      }}
+    mtu: >-
+      {{
+        ansible_facts
+        | dict2items
+        | map(attribute='value')
+        | selectattr(ip_version, 'defined')
+        | selectattr('mtu', 'defined')
+        | selectattr(ip_version + '.address', 'defined')
+        | selectattr(ip_version + '.address', 'equalto', ip_address)
+        | map(attribute='mtu')
+        | list
+        | first
+      }}
+    ip_header_size: >-
+      {{
+        20
+        if ip_version == 'ipv4'
+        else (
+          40
+          if ip_version == 'ipv6'
+          else
+          None
+        )
+      }}
+    icmp_header_size: '8'
+  loop: >-
+    {{
+      group
+      | difference([inventory_hostname])
+      | map('extract', hostvars, 'ansible_facts')
+      | map('dict2items')
+      | map('map', attribute='value')
+      | map('selectattr', ip_version, 'defined')
+      | map('map', attribute=ip_version)
+      | map('selectattr', 'address', 'defined')
+      | map('map', attribute='address')
+      | map('ansible.utils.ipaddr', network_cidr)
+      | list
+      | flatten
+    }}
+  register: ping
+  changed_when: False
+
+- name: Assert that ping check was successful
+  ansible.builtin.assert:
+    that: item.rc == 0
+    quiet: True
+  loop: "{{ ping.results }}"
+  loop_control:
+    label: "{{ item.stdout }}"


### PR DESCRIPTION
The added role will check network connectivity from every host in the provided group to all others. It will use the highest possible data size for the given MTU to send ping echo requests to conduct this test.

Part of https://github.com/osism/issues/issues/1088