### PR TITLE
Switch tempest loadbalancer provider

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -87,7 +87,7 @@ tempest_enable_swift: true
 tempest_image_build_timeout: 600
 
 # loadbalancer
-tempest_loadbalancer_provider: ovn
+tempest_loadbalancer_provider: amphora
 tempest_loadbalancer_enabled_provider_drivers:
   - amphora:Amphora provider
   - ovn:OVN provider


### PR DESCRIPTION
Switch tempest loadbalancer provider to 'amphora'. The reference driver should support all tests in octavia tempest plugin.