### PR TITLE
tempest: use shorter resource name prefix

### DIFF
--- a/roles/tempest/templates/tempest.conf.j2
+++ b/roles/tempest/templates/tempest.conf.j2
@@ -6,8 +6,6 @@
 log_dir = /tempest/logs
 log_file = tempest.log
 
-resource_name_prefix = osism-validation-tempest
-
 [oslo_concurrency]
 lock_path = /tempest/tempest_lock
 


### PR DESCRIPTION
This will fix the following issue:

exceeds the limit of column name(CHAR(64)