### PR TITLE
tempest: set admin_system = all

### DIFF
--- a/roles/tempest/templates/tempest.conf.j2
+++ b/roles/tempest/templates/tempest.conf.j2
@@ -16,6 +16,7 @@ admin_username = {{ tempest_admin_username }}
 admin_password = {{ tempest_admin_password }}
 admin_project_name = {{ tempest_admin_project_name }}
 admin_domain_name = {{ tempest_admin_domain_name }}
+admin_system = all
 
 {% if tempest_enable_nova | bool -%}
 [compute]


### PR DESCRIPTION
The system scope on which an admin user has an admin role assignment, if any. Valid values are 'all' or None. This must be set to 'all' if using the [oslo_policy]/enforce_scope=true option for the identity service. (string value)