### PR TITLE
Fix include/exclude lists logic

### DIFF
--- a/roles/tempest/tasks/main.yml
+++ b/roles/tempest/tasks/main.yml
@@ -291,9 +291,9 @@
             +
             (['--exclude-regex', tempest_exclude_regex] if tempest_exclude_regex is defined and tempest_exclude_regex | length > 0 else [])
             +
-            (['--exclude-list', '/opt/tempest/exclude.lst'] if result_exclude_list.stat.exists else [])
+            (['--exclude-list', '/tempest/exclude.lst'] if result_exclude_list.stat.exists else [])
             +
-            (['--include-list', '/opt/tempest/include.lst'] if result_include_list.stat.exists else [])
+            (['--include-list', '/tempest/include.lst'] if result_include_list.stat.exists else [])
           }}
       tags: run-tempest
       block:  # noqa: osism-fqcn


### PR DESCRIPTION
There was a (copy-paste?) typo and wrong path in the include/exclude list logic.

I've used the patched version successfully to start run tempest against an include list.