### PR TITLE
molecule: add default stub to silence CRITICAL error

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,10 @@
+---
+# Stub scenario that prevents molecule from logging a CRITICAL error
+# when looking for shared state before each test run. Has no platforms
+# and no functionality; it only needs to be loadable.
+scenario:
+  name: default
+  test_sequence: []
+platforms: []
+provisioner:
+  name: ansible


### PR DESCRIPTION
## Summary

- Molecule always tries to load `molecule/default/molecule.yml` before running any scenario to set up shared state. When the file is absent it logs a misleading `CRITICAL 'molecule/default/molecule.yml' glob failed. Exiting.` message even though execution continues normally.
- Adds a minimal stub scenario with no platforms (`platforms: []`) and an empty `test_sequence: []`. The stub is loadable but does nothing — shared state stays disabled, and running `molecule test -s default` directly is a no-op rather than crashing at converge.

## Test plan

- [ ] Run any molecule scenario (e.g. `molecule test -s delegated -e ANSIBLE_ROLE=sshd`) and confirm the `CRITICAL` line no longer appears
- [ ] Run `molecule test -s default` and confirm it completes immediately with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Related PRs

Same molecule default-stub fix across collections:

- osism/ansible-collection-services#2087
- osism/ansible-collection-commons#852
- osism/ansible-collection-validations#261 (this PR)
