### PR TITLE
ansible: drop obsolete osism-fqcn noqa on blocks

### DIFF
--- a/roles/docker_version/tasks/assert-version-Debian.yml
+++ b/roles/docker_version/tasks/assert-version-Debian.yml
@@ -12,7 +12,7 @@
     package_version_revision: "{{ package_version | split('-') | last if '-' in package_version else '' }}"
     _package_version_tail: "{{ (package_version | split(':'))[1:] | join(':') if ':' in package_version else package_version }}"
     package_version_upstream: "{{ (_package_version_tail | split('-'))[:-1] | join('-') if '-' in _package_version_tail else _package_version_tail }}"
-  block:  # noqa osism-fqcn
+  block:
     - name: Assert that only a single docker version is installed
       ansible.builtin.assert:
         that: package_versions | length == 1

--- a/roles/docker_version/tasks/main.yml
+++ b/roles/docker_version/tasks/main.yml
@@ -11,7 +11,7 @@
     expected_version: "{{ docker_version_expected | default('') }}"
     package_versions: "{{ ansible_facts.packages[docker_package_name | default('docker-ce')] | map(attribute='version') | list }}"
     running_version: "{{ running.host_info.ServerVersion }}"
-  block:  # noqa osism-fqcn
+  block:
     - name: Overview of docker versions found
       ansible.builtin.debug:
         msg:

--- a/roles/tempest/tasks/main.yml
+++ b/roles/tempest/tasks/main.yml
@@ -73,7 +73,7 @@
 - name: Resolve img_file or network api extensions
   when:
     - tempest_img_file is undefined or tempest_api_extensions is undefined
-  block:  # noqa: osism-fqcn
+  block:
     - name: Get auth token
       delegate_to: localhost
       openstack.cloud.auth:
@@ -168,7 +168,7 @@
     tempest_img_file: "/tempest/{{ _img_file_name }}"
 
 - name: Resolve floating network ID
-  block:  # noqa: osism-fqcn
+  block:
     - name: Resolve floating network ID
       delegate_to: localhost
       openstack.cloud.networks_info:
@@ -185,7 +185,7 @@
 - name: Resolve flavor IDs
   when:
     - not tempest_create_flavors | bool
-  block:  # noqa: osism-fqcn
+  block:
     - name: Resolve flavor IDs
       delegate_to: localhost
       openstack.cloud.compute_flavor_info:
@@ -234,7 +234,7 @@
   when: result_include_list.stat.exists
 
 - name: Prepare and run tempest
-  block:  # noqa: osism-fqcn
+  block:
     - name: Create tempest flavors
       delegate_to: localhost
       openstack.cloud.compute_flavor:
@@ -296,7 +296,7 @@
             (['--include-list', '/tempest/include.lst'] if result_include_list.stat.exists else [])
           }}
       tags: run-tempest
-      block:  # noqa: osism-fqcn
+      block:
         - name: Register selected tempest tests
           community.docker.docker_container:
             <<: *docker_common_opt


### PR DESCRIPTION
Remove obsolete `# noqa: osism-fqcn` ansible-lint annotations from
`block:` constructs.

The custom `osism-fqcn` ansible-lint rule used to emit spurious
violations on `block`/`rescue`/`always` constructs. osism/container-images#902
fixed the rule and the updated `ansible-lint` image is now published, so
these `# noqa` workarounds are obsolete. All removed annotations sat on
`block:` false-positives, so dropping them leaves linting behaviour
unchanged.

Files changed:
- `roles/docker_version/tasks/assert-version-Debian.yml`
- `roles/docker_version/tasks/main.yml`
- `roles/tempest/tasks/main.yml`

Part of the cleanup sweep tracked in osism/issues#1368.

Related-Bug: #1368