### PR TITLE
tempest: default admin password from keystone

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -26,7 +26,7 @@ tempest_concurrency: 1
 
 # auth
 tempest_admin_username: admin
-tempest_admin_password: password
+tempest_admin_password: "{{ keystone_admin_password | default('password') }}"
 tempest_admin_project_name: admin
 tempest_admin_domain_name: Default
 tempest_roles:


### PR DESCRIPTION
## Problem

The `tempest` role authenticates every OpenStack task via the `&os_auth` anchor (`roles/tempest/tasks/main.yml`) with an explicit `auth_type: password` built from the `tempest_admin_*` vars, and `tempest_admin_password` defaulted to the literal string `password`.

That only works on the OSISM testbed, whose `keystone_admin_password` is itself literally `password`. On any deployment with a real admin secret, `osism apply tempest` fails at the first OpenStack task (`Resolve image IDs`) with:

```
keystoneauth1.exceptions.http.Unauthorized: The request you have made requires authentication. (HTTP 401)
```

## Fix

Default `tempest_admin_password` to `"{{ keystone_admin_password | default('password') }}"`, so the role uses the deployment's real admin secret when it is resolvable while preserving the testbed's existing behaviour (where `keystone_admin_password` is `password`).

## Notes

- Companion fix for the same `osism apply tempest`-on-a-real-cloud failure mode:
  - osism/ansible-collection-validations#269

🤖 Generated with [Claude Code](https://claude.com/claude-code)