### PR TITLE
tempest: scope tempest_roles to enabled services

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -29,10 +29,9 @@ tempest_admin_username: admin
 tempest_admin_password: password
 tempest_admin_project_name: admin
 tempest_admin_domain_name: Default
-tempest_roles:
-  - creator
-  - load-balancer_member
-  - member
+# Assign only the roles whose backing service is deployed: creator is created
+# by barbican, load-balancer_member by octavia (see tempest_enable_* below).
+tempest_roles: "{{ ['member'] + (['creator'] if tempest_enable_barbican | bool else []) + (['load-balancer_member'] if tempest_enable_octavia | bool else []) }}"
 
 # identity
 tempest_uri_v3: https://api.testbed.osism.xyz:5000/v3


### PR DESCRIPTION
## Problem

`tempest_roles` defaulted to `[creator, load-balancer_member, member]` and is rendered into `tempest.conf` as `tempest_roles = ...`. Tempest's dynamic credential provider assigns every listed role to each test account, so each role must already exist in keystone.

But `creator` and `load-balancer_member` are not base roles: `creator` is created by the **barbican** service deploy (kolla-ansible `barbican_creator_role`, in `barbican_ks_roles`) and `load-balancer_member` by **octavia** — both off by default. These roles exist only where those services are deployed (the OSISM testbed and many production environments), but not in a deployment that runs neither. On such a deployment `osism apply tempest` fails every test in `setUpClass -> setup_credentials`:

```
tempest.lib.exceptions.NotFound: Object not found
Details: No "creator" role found
```

## Fix

Derive `tempest_roles` from the existing `tempest_enable_*` service knobs instead of hardcoding the full set: always include `member`, add `creator` only when `tempest_enable_barbican`, and `load-balancer_member` only when `tempest_enable_octavia`.

When both are enabled (the current default and the testbed's configuration) the role set is unchanged, so this does not regress existing runs; a deployment that disables barbican/octavia no longer requests roles keystone does not have.

## Notes

- Wiring the `tempest_enable_*` knobs to a deployment's real `enable_<service>` state remains an integration-layer concern (the play runs only `osism.validations.tempest` on the manager and does not see kolla's `enable_*` vars) — out of scope here.
- Companion fix for the same `osism apply tempest`-on-a-real-cloud failure mode:
  - osism/ansible-collection-validations#268

🤖 Generated with [Claude Code](https://claude.com/claude-code)