### PR TITLE
tempest: fix amphora provider description string

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -96,7 +96,7 @@ tempest_image_build_timeout: 600
 # loadbalancer
 tempest_loadbalancer_provider: amphora
 tempest_loadbalancer_enabled_provider_drivers:
-  - amphora:Amphora driver
+  - amphora:Amphora provider
 tempest_loadblancer_not_implemented_is_error: false  # ovn provider does not implement all features
 
 # object-storage


### PR DESCRIPTION
## Summary
- `tempest_loadbalancer_enabled_provider_drivers` defaulted to `amphora:Amphora driver`, but kolla-ansible's own `octavia_provider_drivers` default (and hence what Octavia's API actually returns) is `amphora:Amphora provider`.
- Traced to commit 2717094 (#227), which switched the tested provider from `ovn` to `amphora` but didn't match kolla-ansible's actual description string.
- Causes `octavia_tempest_plugin.tests.api.v2.test_provider.ProviderAPITest.test_provider_list` to fail with a `MismatchError` on every full-profile run that exercises this test. Purely a test-config string; no functional impact on deployed clouds.

## Test plan
- [x] `yamllint` clean (via `osism-zuul-lint`)
- [ ] Confirm `test_provider_list` passes on the next full-profile tempest run against a kolla-ansible-deployed cloud