### PR TITLE
tempest: add opt-in tempest_debug var

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -24,6 +24,13 @@ tempest_include_list: /opt/configuration/environments/openstack/files/tempest/in
 
 tempest_concurrency: 1
 
+# When true, tempest.lib's rest_client logs full request/response headers and
+# bodies (not just "status method url" at INFO) to tempest.log -- the only way
+# to capture evidence like a console-log response body if a test needs one and
+# cleanup runs before a human can look. Off by default: full-profile runs make
+# many thousands of calls, and logging every body is a real log-volume cost.
+tempest_debug: false
+
 # auth
 tempest_admin_username: admin
 tempest_admin_password: "{{ keystone_admin_password | default('password') }}"

--- a/roles/tempest/templates/tempest.conf.j2
+++ b/roles/tempest/templates/tempest.conf.j2
@@ -5,6 +5,7 @@
 [DEFAULT]
 log_dir = /tempest/logs
 log_file = tempest.log
+debug = {{ tempest_debug }}
 
 [oslo_concurrency]
 lock_path = /tempest/tempest_lock


### PR DESCRIPTION
## Summary
- `tempest.lib`'s `rest_client` only logs full request/response **headers and bodies** when its logger is at DEBUG. This role never sets `[DEFAULT] debug`, so it is always effectively `false` and that evidence is never captured — which is why, e.g., a console-log API response body fetched by a failing test is unrecoverable once test cleanup deletes the instance.
- Adds a `tempest_debug` var (default `false`, section value `debug = {{ tempest_debug }}`), so a consumer investigating a rare failure whose evidence disappears after cleanup can opt in to full-body logging without a template change of their own.
- Default is unchanged behavior for every existing consumer; `false` keeps the current INFO-level `status method url` logging and avoids the log-volume cost of logging every body across a multi-thousand-call full-profile run.

## Test plan
- [x] `yamllint` / `flake8` clean (via `osism-zuul-lint`)
- [x] Confirm on a full-profile tempest run (with `tempest_debug: true`) that `tempest.log` contains full request/response bodies

## Live validation (2026-07-18, full `latest` profile run)
Validated on a full-profile run (4064 tests) deployed with this branch active (delivered via a locally-built `osism-ansible` image):

- **Works as intended.** The generated `tempest.conf` had `[DEFAULT] debug = True`, and `tempest.log` carried the full bodies — **321,209** debug-only body/header log entries vs **80,311** baseline `INFO Request` lines that appear regardless of the setting.
- **The cost is log volume, not runtime.** The log was **196 MB** (roughly an order of magnitude larger than a non-debug run). Wall-clock was 11h12m for 4064 tests — no measurable slowdown vs a comparable debug-*off* run (14h08m / 4067 tests, other hardware); per-call logging overhead is negligible against real test work.
