### PR TITLE
tempest: add opt-in neutron_plugin_options dns_domain

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -77,6 +77,11 @@ tempest_port_security: true
 tempest_ipv6_subnet_attributes: true
 tempest_floating_ip_network: public
 tempest_network_build_timeout: 600
+# unset (no [neutron_plugin_options] section emitted) by default, matching
+# neutron_tempest_plugin's own fallback (openstackgate.local); set this to the
+# deployment's real neutron.conf dns_domain so internal-DNS scenario tests
+# check against the right value instead of a placeholder that never matches.
+tempest_neutron_dns_domain: ""
 
 # service_available
 tempest_enable_barbican: true

--- a/roles/tempest/templates/tempest.conf.j2
+++ b/roles/tempest/templates/tempest.conf.j2
@@ -97,6 +97,11 @@ build_timeout = {{ tempest_network_build_timeout }}
 port_security = {{ tempest_port_security | string }}
 ipv6_subnet_attributes = {{ tempest_ipv6_subnet_attributes | string }}
 api_extensions = {{ tempest_api_extensions }}
+{% if tempest_neutron_dns_domain -%}
+
+[neutron_plugin_options]
+dns_domain = {{ tempest_neutron_dns_domain }}
+{% endif -%}
 {%- endif %}
 
 {% if tempest_enable_swift | bool -%}


### PR DESCRIPTION
## Summary
- `neutron_tempest_plugin`'s internal-DNS scenario tests compare the guest's `resolv.conf` search domain against `CONF.neutron_plugin_options.dns_domain`, which falls back to the placeholder `openstackgate.local` when nothing emits a `[neutron_plugin_options]` section — a section this role has never written.
- Any deployment whose real `neutron.conf` `dns_domain` differs (i.e. any deployment with a real domain) therefore fails that comparison against a value that was never meant to match anything. Observed as `InternalDNSTest.test_dns_domain_and_name` failing with the guest's actual domain vs. the stale `openstackgate.local` default.
- Adds a `tempest_neutron_dns_domain` var (default `""`, section omitted → unchanged behavior for existing consumers). Set it to the deployment's real `neutron.conf` `dns_domain` and the role emits `[neutron_plugin_options] dns_domain = <value>`.

## Test plan
- [x] `yamllint` / `flake8` clean (via `osism-zuul-lint`)
- [x] Confirm the change takes effect: `[neutron_plugin_options] dns_domain` rendered into `tempest.conf`, and the original resolv.conf-mismatch assertion now passes

## Live validation (2026-07-18, full `latest` profile run)
Validated on a full-profile run deployed with this branch active (delivered via a locally-built `osism-ansible` image), `tempest_neutron_dns_domain: tbng.osism.xyz.`:

- **Correct and effective for its purpose.** The generated `tempest.conf` had `[neutron_plugin_options] dns_domain = tbng.osism.xyz.`, matching the deployed `neutron.conf` `[DEFAULT] dns_domain`.
- **It fixes the original failure.** On the validation run the resolv.conf assertions (`assertIn(dns_domain, resolv_conf)` / `assertNotIn('starwars', …)`) **passed** — that comparison, the stale `openstackgate.local` default vs. the real deployed domain, was the exact original failure this change targets.
