### PR TITLE
tempest: derive octavia providers from API

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -107,8 +107,18 @@ tempest_image_build_timeout: 600
 
 # loadbalancer
 tempest_loadbalancer_provider: amphora
-tempest_loadbalancer_enabled_provider_drivers:
-  - amphora:Amphora provider
+# tempest_loadbalancer_enabled_provider_drivers is derived at runtime (see
+# tasks/main.yml) from the providers the deployed Octavia API actually serves
+# (GET /v2.0/lbaas/providers). Octavia enables amphora plus, when
+# neutron_plugin_agent is ovn, the ovn provider; that condition is evaluated in
+# kolla-ansible's scope and is not reachable here, so hardcoding the list makes
+# it diverge from the deployment and octavia_tempest_plugin's test_provider_list
+# then KeyErrors on the undeclared provider. Deriving it from the live API keeps
+# the expected list correct for any deployment. Set this variable explicitly to
+# override the derivation, e.g.:
+# tempest_loadbalancer_enabled_provider_drivers:
+#   - amphora:Amphora provider
+#   - ovn:OVN provider
 tempest_loadblancer_not_implemented_is_error: false  # ovn provider does not implement all features
 
 # object-storage

--- a/roles/tempest/tasks/main.yml
+++ b/roles/tempest/tasks/main.yml
@@ -70,9 +70,9 @@
     that:
       - _images.results | map(attribute='images') | flatten | map(attribute='id') | list | unique | length == 2
 
-- name: Resolve img_file or network api extensions
+- name: Resolve img_file, network api extensions or octavia providers
   when:
-    - tempest_img_file is undefined or tempest_api_extensions is undefined
+    - tempest_img_file is undefined or tempest_api_extensions is undefined or (tempest_enable_octavia | bool and tempest_loadbalancer_enabled_provider_drivers is undefined)
   block:
     - name: Get auth token
       delegate_to: localhost
@@ -141,6 +141,19 @@
         method: GET
         url: "{{ _endpoints.json.endpoints | selectattr('interface', 'equalto', 'public') | selectattr('service_id', 'equalto', service_id) | map(attribute='url') | first }}/v2.0/extensions"
       register: _network_api_extensions
+
+    - name: Get Octavia providers
+      delegate_to: localhost
+      when:
+        - tempest_enable_octavia | bool
+        - tempest_loadbalancer_enabled_provider_drivers is undefined
+      vars:
+        service_id: "{{ _service_catalog.services | selectattr('type', 'equalto', 'load-balancer') | selectattr('is_enabled', 'truthy') | map(attribute='id') | first }}"
+      ansible.builtin.uri:
+        headers: *os_auth_headers
+        method: GET
+        url: "{{ _endpoints.json.endpoints | selectattr('interface', 'equalto', 'public') | selectattr('service_id', 'equalto', service_id) | map(attribute='url') | first }}/v2.0/lbaas/providers"
+      register: _octavia_providers
   always:
     - name: Revoke token
       delegate_to: localhost
@@ -159,6 +172,17 @@
     - tempest_api_extensions is undefined
   ansible.builtin.set_fact:
     tempest_api_extensions: "{{ _network_api_extensions.json.extensions | map(attribute='alias') | join(',') }}"
+
+- name: Set fact for config option enabled_provider_drivers
+  delegate_to: localhost
+  when:
+    - tempest_enable_octavia | bool
+    - tempest_loadbalancer_enabled_provider_drivers is undefined
+  ansible.builtin.set_fact:
+    tempest_loadbalancer_enabled_provider_drivers: >-
+      {{ _octavia_providers.json.providers | map(attribute='name')
+         | zip(_octavia_providers.json.providers | map(attribute='description'))
+         | map('join', ':') | list }}
 
 - name: Set fact for config option img_file
   delegate_to: localhost


### PR DESCRIPTION
## Problem

`octavia_tempest_plugin`'s `ProviderAPITest.test_provider_list` iterates the
providers the deployed Octavia API returns and looks each up, by name, in the
`enabled_provider_drivers` dict from `tempest.conf`. On an OVN deployment
Octavia serves **both** `amphora` and `ovn`, but the role hardcoded an
amphora-only list, so the test hit a `KeyError` on the `ovn` provider and
failed. It surfaced only after the amphora description string was fixed and the
test loop could advance past `amphora`:

- osism/ansible-collection-validations#271

## Why not just mirror kolla's condition

The correct list is deployment-dependent: kolla-ansible builds
`octavia_provider_drivers` as `amphora:Amphora provider` plus, when
`neutron_plugin_agent` is `ovn`, `, ovn:OVN provider`. That condition is
evaluated in kolla-ansible's variable scope, which is **not reachable** when
this role renders `tempest.conf`:

- `octavia_provider_drivers` is a kolla-ansible role default — undefined in this
  role's run scope.
- The tempest playbook runs in the `openstack` environment, but octavia/neutron
  operator settings live in the `kolla` environment config, which is not loaded
  there. `neutron_plugin_agent` therefore resolves to the `osism/defaults`
  default rather than the operator's deploy value, so mirroring it would
  silently diverge from the actual deployment on a non-OVN cloud.

## Fix

Derive `tempest_loadbalancer_enabled_provider_drivers` at runtime from the
providers the live Octavia API actually serves. A new task GETs
`{load-balancer endpoint}/v2.0/lbaas/providers` — reusing the auth token,
endpoint catalog and service catalog the role already discovers for image and
network setup — and a `set_fact` builds one `name:description` entry per served
provider. This mirrors the existing `tempest_api_extensions` derivation and
keeps the expected list correct for any deployment (amphora alone, or amphora
plus ovn) by construction.

The default is now undefined (with an explanatory comment) rather than a
hardcoded list, so it is derived when octavia is enabled and can still be
overridden by setting the variable explicitly.

## Verification

Verified end to end against a live deployment: the derived value renders as
`amphora:Amphora provider,ovn:OVN provider` and `test_provider_list` no longer
KeyErrors. `ansible-lint` (production profile) and `yamllint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)