### PR TITLE
tempest: document workflows and make wrapper exclude-list optional

### DIFF
--- a/roles/tempest/README.md
+++ b/roles/tempest/README.md
@@ -1,0 +1,59 @@
+# tempest
+
+Prepares a Tempest workspace on the manager and runs the OpenStack integration
+test suite against the deployed cloud via the OSISM Tempest container image.
+
+## Running
+
+### Full run
+
+```
+osism apply tempest
+```
+
+Stages everything (workspace init, image download and qcow2 conversion,
+image/flavor/endpoint resolution, `tempest.conf` render, exclude/include lists),
+runs the full suite, and removes the flavors it created. This is the normal
+invocation and takes several hours.
+
+### Setup only — stage the workspace without running the tests
+
+```
+osism apply tempest --skip-tags run-tempest
+```
+
+Runs the entire setup and stops before executing the tests, leaving a staged
+workspace (and the created flavors) in place. Use it either to check that staging
+works — image download/convert, flavor creation, `tempest.conf` render — in
+minutes instead of hours, or to prepare the workspace cheaply for a subset run
+with the `tempest` wrapper (below), without first paying for a full run.
+
+Do **not** invoke the `run-tempest` tag the other way as `-t run-tempest` /
+`--tags run-tempest`: that runs *only* the tagged tasks and skips the setup
+they depend on (it fails on an undefined `result_exclude_list` and would remove
+flavors it did not create).
+
+### Run a subset — iterate on specific tests while debugging
+
+After a setup-only run (above) has staged the workspace, run a subset directly on
+the manager with the wrapper the role installs at `/usr/local/bin/tempest`:
+
+```
+tempest '<regex>'
+```
+
+for example:
+
+```
+tempest 'PortForwardingTestJSON.*udp'
+```
+
+The wrapper runs the Tempest container against the persisted workspace and
+`tempest.conf` — no image download, no re-resolution, no Ansible — and appends
+output to a timestamped log in the work directory. This is the fast way to re-run
+specific tests during debugging.
+
+A full `osism apply tempest` is not a suitable predecessor: it removes the
+flavors it created, leaving `tempest.conf` pointing at flavor IDs that no longer
+exist (unless `tempest_create_flavors` is `false`, where flavors are pre-existing
+and kept).

--- a/roles/tempest/templates/tempest.j2
+++ b/roles/tempest/templates/tempest.j2
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Pass --exclude-list only when an exclude list was staged. tempest runs fine
+# without one -- the regex alone selects the tests -- so a deployment that ships
+# no exclude list is not forced to have this file.
+exclude_args=()
+if [[ -f {{ tempest_workdir }}/exclude.lst ]]; then
+  exclude_args=(--exclude-list /tempest/exclude.lst)
+fi
+
 docker run --rm \
   -v {{ tempest_workdir }}:/tempest \
   -v /etc/ssl/certs:/etc/ssl/certs:ro \
@@ -9,6 +17,6 @@ docker run --rm \
   run \
   --workspace-path /tempest/workspace.yaml \
   --workspace {{ tempest_workspace_name }} \
-  --exclude-list /tempest/exclude.lst \
+  "${exclude_args[@]}" \
   --regex "$1" \
   --concurrency {{ tempest_concurrency }} | tee -a {{ tempest_workdir }}/$(date +%Y%m%d-%H%M).log


### PR DESCRIPTION
## What

Two small, related changes to the `tempest` role. No change to the full-run behaviour.

- Make the installed `tempest` wrapper pass `--exclude-list` only when the file exists.
- Document the role's invocation workflows (the README was empty).

## Why

While re-running individual tests during a CI investigation, `osism apply tempest -t run-tempest` failed confusingly. Digging in showed the `run-tempest` tag is an **opt-out** marker (for `--skip-tags run-tempest`), not an opt-in entry point — so the real gap was discoverability, not a missing feature. Separately, the wrapper hardcoded an exclude list it doesn't actually require.

## Wrapper: don't require an exclude list

`roles/tempest/templates/tempest.j2` hardcoded `--exclude-list /tempest/exclude.lst`, so it broke on any deployment that ships no exclude list. tempest needs only `--regex` to select tests; the exclude list is an optional skip-list for known-incompatible tests. The wrapper now builds the argument at runtime and passes `--exclude-list` only when the file is present (still applied when it is).

Verified by rendering the Jinja to concrete values and running it both ways:

- no `exclude.lst` → `run … --regex <r> --concurrency 16` (no `--exclude-list`)
- `exclude.lst` present → `run … --exclude-list /tempest/exclude.lst --regex <r> …`

## Docs: three invocation workflows

The role README now documents:

- **Full run** — `osism apply tempest` (stage everything, run the whole suite, remove created flavors).
- **Setup only** — `osism apply tempest --skip-tags run-tempest` (run the staging path and stop; validates setup in minutes and cheaply prepares the workspace for subset runs). Notes that `-t run-tempest` is not a valid invocation.
- **Subset / debugging** — the `tempest '<regex>'` wrapper against the staged workspace. Notes that a full run is not a valid predecessor for it, since a full run tears down its flavors and leaves `tempest.conf` referencing deleted flavor IDs.

## Notes

- No task logic changes; the full run and `--skip-tags run-tempest` behave exactly as before.
- An earlier attempt to make `-t run-tempest` a working entry point was dropped: the setup it skips only matters for subset runs, which the wrapper (and `--skip-tags` staging) already handle better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)