### PR TITLE
tempest: discover optional services from catalog

### DIFF
--- a/roles/tempest/defaults/main.yml
+++ b/roles/tempest/defaults/main.yml
@@ -91,16 +91,37 @@ tempest_network_build_timeout: 600
 tempest_neutron_dns_domain: ""
 
 # service_available
-tempest_enable_barbican: true
+# The OPTIONAL services -- barbican, designate, octavia and swift -- are
+# deliberately NOT given a value here. tasks/main.yml derives each one that is
+# still undefined from the service catalog, which is the only source that
+# reflects what the cloud actually offers.
+#
+# kolla's enable_<service> is not such a source: for a role running in the
+# openstack environment those variables resolve from inventory, not from the
+# kolla environment where a deployment actually sets them, so they can read
+# "enabled" for a service that was never deployed. Getting this wrong is not a
+# partial failure -- tempest_roles above asks keystone for roles that only
+# barbican and octavia create, and an absent role fails every test using
+# dynamic credentials, in setUpClass.
+#
+#   tempest_enable_barbican    <- 'key-manager' in the catalog
+#   tempest_enable_designate   <- 'dns'
+#   tempest_enable_octavia     <- 'load-balancer'
+#   tempest_enable_swift       <- 'object-store'
+#
+# Set any of them explicitly to override the derived value. Setting ALL of them
+# skips the catalog lookup entirely, so the role can run against a cloud whose
+# catalog cannot be enumerated.
+
+# The core services: an OSISM deployment without these is not a deployment worth
+# running tempest against, so they stay unconditional. horizon is not a catalog
+# service at all (it registers no keystone endpoint), so it cannot be discovered.
 tempest_enable_cinder: true
-tempest_enable_designate: true
 tempest_enable_glance: true
 tempest_enable_horizon: true
 tempest_enable_keystone: true
 tempest_enable_neutron: true
 tempest_enable_nova: true
-tempest_enable_octavia: true
-tempest_enable_swift: true
 
 # image
 tempest_image_build_timeout: 600

--- a/roles/tempest/tasks/main.yml
+++ b/roles/tempest/tasks/main.yml
@@ -70,6 +70,52 @@
     that:
       - _images.results | map(attribute='images') | flatten | map(attribute='id') | list | unique | length == 2
 
+# Derive the optional-service flags, so a deployment that does not run barbican,
+# designate, octavia or swift neither advertises them in [service_available] nor
+# asks keystone for roles that only those services create. This must stay ahead
+# of the first consumer of a tempest_enable_* flag.
+#
+# Skipped when every flag is already set: an operator who configures all four
+# explicitly can then run against a cloud whose catalog cannot be enumerated.
+- name: Get service catalog for service discovery
+  delegate_to: localhost
+  when: >-
+    tempest_enable_barbican is undefined
+    or tempest_enable_designate is undefined
+    or tempest_enable_octavia is undefined
+    or tempest_enable_swift is undefined
+  openstack.cloud.catalog_service_info:
+    <<: *os_auth
+  register: _catalog
+
+- name: Derive the optional service flags from the catalog
+  when: not (_catalog.skipped | default(false))
+  vars:
+    _types: "{{ _catalog.services | default([]) | selectattr('is_enabled', 'truthy') | map(attribute='type') | list }}"
+  block:
+    # An empty catalog would resolve every optional service to disabled and skip
+    # its tests silently, which looks just like a correct run on a minimal
+    # deployment. Check the lookup result itself: a cloud need not register
+    # keystone in its own catalog, so the presence of any particular service --
+    # identity included -- says nothing about whether the lookup worked.
+    - name: Assert the service catalog was returned
+      ansible.builtin.assert:
+        that:
+          - _catalog.services is defined
+          - _catalog.services | length > 0
+        fail_msg: >-
+          The service catalog came back empty, so the optional services cannot be
+          discovered. Set tempest_enable_barbican, tempest_enable_designate,
+          tempest_enable_octavia and tempest_enable_swift explicitly to run
+          tempest without service discovery.
+
+    - name: Set the optional service flags
+      ansible.builtin.set_fact:
+        tempest_enable_barbican: "{{ tempest_enable_barbican | default('key-manager' in _types) }}"
+        tempest_enable_designate: "{{ tempest_enable_designate | default('dns' in _types) }}"
+        tempest_enable_octavia: "{{ tempest_enable_octavia | default('load-balancer' in _types) }}"
+        tempest_enable_swift: "{{ tempest_enable_swift | default('object-store' in _types) }}"
+
 - name: Resolve img_file, network api extensions or octavia providers
   when:
     - tempest_img_file is undefined or tempest_api_extensions is undefined or (tempest_enable_octavia | bool and tempest_loadbalancer_enabled_provider_drivers is undefined)


### PR DESCRIPTION
`tempest_enable_*` described which services a deployment runs, but every one defaulted to an unconditional `true` and nothing in the deployment path ever set them — not `osism/defaults`, not `ansible-playbooks`, not the configuration repository. On a deployment that omits an optional service the role asserted the service was present, and two things went wrong.

**Fatal during setup.** `Get Octavia providers` runs when `tempest_enable_octavia` is true and resolves the `load-balancer` service out of the catalog, so without octavia it fails with `No first item, sequence was empty` and the role never reaches tempest.

**Latent behind it.** `tempest_roles` was scoped to enabled services in:

- osism/ansible-collection-validations#269

but it derives them from these same flags, so it still asks for `creator` (barbican) and `load-balancer_member` (octavia). Tempest's dynamic credential provider assigns every listed role when creating a test user, and a role keystone does not have fails **every** test using dynamic credentials in `setUpClass` — not just the tests for the missing service.

## Why not kolla's `enable_<service>`

It is not a usable source here. This role runs in the **openstack** environment, and `run-openstack.sh` loads only `environments/{configuration,secrets}.yml` plus the openstack environment files. The kolla environment — where a deployment actually sets `enable_octavia` — is never loaded, so the variable resolves from inventory instead, where OSISM's own `defaults/all/099-kolla.yml` sets it to `"yes"`. It reads *enabled* for a service that was never deployed.

## What this does

Derives the four optional flags from the service catalog, the one source reflecting what the cloud actually offers. The role already queried the catalog, but only inside a block whose condition reads `tempest_enable_octavia`; this hoists a lookup ahead of the first consumer of any flag.

| variable | catalog service type |
|---|---|
| `tempest_enable_barbican` | `key-manager` |
| `tempest_enable_designate` | `dns` |
| `tempest_enable_octavia` | `load-balancer` |
| `tempest_enable_swift` | `object-store` |

A deployed service registers its endpoint and so enables itself — no operator action needed in either direction.

The four are given **no value** in defaults, which is what makes an explicitly configured flag distinguishable from a derived one. Setting one overrides the derived value; setting all four skips the lookup entirely, so the role still runs against a cloud whose catalog cannot be enumerated. They stay documented in `defaults/main.yml` next to the type each derives from.

The assert checks that the lookup returned a **non-empty catalog**, not that some known service is in it — a cloud need not register keystone in its own catalog, so the presence of any particular service says nothing about whether the lookup worked. An empty result would otherwise disable every optional service and skip its tests silently, which looks exactly like a correct run on a minimal deployment.

Core services stay unconditional: a deployment without cinder, glance, neutron, nova or keystone is not one worth running tempest against. `horizon` stays unconditional because it registers no keystone endpoint and cannot be discovered this way.

## Verification

Live deployment running neither barbican, designate, octavia nor swift.

| | catalog lookup | `tempest_roles` | result |
|---|---|---|---|
| before this change | ran | — | **`failed=1`** at `Get Octavia providers`, no `tempest.conf` |
| derived | ran | `member` | `ok=33 failed=0`, 5/5 tests passed |
| all four set explicitly | **skipped** | `member` | `swift = true` preserved against a catalog with no `object-store` |

Rendered `[service_available]` on the derived run matched the catalog exactly — `designate`, `key_manager`, `load_balancer`, `swift` false; deployed services true.

## UpgradeImpact

Deployments that relied on the flags defaulting to `true` now get values derived from the catalog. A service whose endpoint is not registered in keystone is reported unavailable and its tests are **skipped rather than run and failed**. Set the `tempest_enable_*` variable explicitly to restore the previous value for such a service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)